### PR TITLE
Replace null return of AfterDispatch with Enumerable.Empty

### DIFF
--- a/src/Blazor.Fluxor/IMiddleware.cs
+++ b/src/Blazor.Fluxor/IMiddleware.cs
@@ -37,7 +37,7 @@ namespace Blazor.Fluxor
 		/// Called after each action dispatched
 		/// </summary>
 		/// <param name="action">The action that has just been dispatched</param>
-        /// <returns>A collection of actions to dispatch. Null is a valid return value.</returns>
+        /// <returns>A collection of actions to dispatch</returns>
 		IEnumerable<IAction> AfterDispatch(IAction action);
 		/// <summary>
 		/// This should only be called via <see cref="IStore.BeginInternalMiddlewareChange"/>.

--- a/src/Blazor.Fluxor/Middleware.cs
+++ b/src/Blazor.Fluxor/Middleware.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Blazor.Fluxor
 {
@@ -15,7 +16,7 @@ namespace Blazor.Fluxor
 		public virtual void AfterInitializeAllMiddlewares() { }
 		public virtual bool MayDispatchAction(IAction action) => true;
 		public virtual void BeforeDispatch(IAction action) { }
-        public virtual IEnumerable<IAction> AfterDispatch(IAction action) => null;
+        public virtual IEnumerable<IAction> AfterDispatch(IAction action) => Enumerable.Empty<IAction>();
 
 		public virtual void Initialize(IStore store)
 		{

--- a/src/Blazor.Fluxor/ReduxDevTools/ReduxDevToolsMiddleware.cs
+++ b/src/Blazor.Fluxor/ReduxDevTools/ReduxDevToolsMiddleware.cs
@@ -43,7 +43,7 @@ namespace Blazor.Fluxor.ReduxDevTools
 			SequenceNumberOfLatestState++;
 			SequenceNumberOfCurrentState = SequenceNumberOfLatestState;
 
-            return null;
+            return Enumerable.Empty<IAction>();
 		}
 
 		private IDictionary<string, object> GetState()


### PR DESCRIPTION
**Issue**
You allow Null values to be returned from AfterDispatch, but then do a SelectMany, that does not accept nulls.

**Steps**
You can replicate this error by adding 
```
.AddMiddleware<ReduxDevToolsMiddleware>()
.AddMiddleware<RoutingMiddleware>()
```
to sample 02, it throws an exception on Store.cs
```
IEnumerable<IAction> allNewActionsToDispatch = actionsCreatedByMiddlewares.Union(actionsCreatedBySideEffects);
```
**Fix**
Replace that null return with Enumerable.Empty<IAction>