### PR TITLE
Support reducers with inherited interfaces

### DIFF
--- a/src/Blazor.Fluxor/IFeature.cs
+++ b/src/Blazor.Fluxor/IFeature.cs
@@ -36,10 +36,8 @@ namespace Blazor.Fluxor
 		/// Allows a feature to react to an action dispatched via the store. This should not be called by
 		/// consuming applications. Instead you should dispatch actions only via <see cref="IStore.DispatchAsync(IAction)"/>
 		/// </summary>
-		/// <typeparam name="TAction">The type of the action dispatched via the store</typeparam>
 		/// <param name="action">The action dispatched via the store</param>
-		void ReceiveDispatchNotificationFromStore<TAction>(TAction action)
-			where TAction : IAction;
+		void ReceiveDispatchNotificationFromStore(IAction action);
 	}
 
 	/// <summary>

--- a/src/Blazor.Fluxor/Store.cs
+++ b/src/Blazor.Fluxor/Store.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 using Blazor.Fluxor.Temporary;
 using Microsoft.AspNetCore.Blazor;
@@ -68,7 +67,7 @@ namespace Blazor.Fluxor
 				// Notify all features of this action
 				foreach (var featureInstance in FeaturesByName.Values)
 				{
-					NotifyFeatureOfDispatch(featureInstance, currentActionToDispatch);
+				    featureInstance.ReceiveDispatchNotificationFromStore(currentActionToDispatch);
 				};
 				FluxorComponent.AllStateHasChanged();
 
@@ -204,19 +203,7 @@ namespace Blazor.Fluxor
             return actionsToDispatch;
 		}
 
-		private void NotifyFeatureOfDispatch(IFeature feature, IAction action)
-		{
-			string methodName = nameof(IFeature.ReceiveDispatchNotificationFromStore);
-			// We need the generic method for the feature instance
-			MethodInfo methodInfo = feature
-				.GetType()
-				.GetMethod(methodName)
-				.MakeGenericMethod(action.GetType());
-
-			methodInfo.Invoke(feature, new object[] { action });
-		}
-
-		private void ActivateStore()
+	    private void ActivateStore()
 		{
 			if (HasActivatedStore)
 				return;


### PR DESCRIPTION
**Intent**
The idea with this PR is to support reducers that trigger with actions that inherit from interfaces (in addition to IAction)

**Sample code**
On sample 02, the GetForecastDataAction has an action that initiates a data fetch. In more complex applications, you would have multiple actions like this, and each would have to have its own reducer to, for instance, change the UI to signal we are fetching data. Rather than implement multiple reducers to do this, you would change GetForecastAction to
```
public class GetForecastDataAction: IStartFetchAction
{
}

public interface IStartFetchAction : IAction
{
}
```
You could then have  a feature for this common state
```
public class VisualStateFeature : Feature<VisualState>
{
    public override string GetName()
    {
        return "VisualState";
    }

    protected override VisualState GetInitialState()
    {
        return new VisualState {IsLoading = false};
    }
}

public class VisualState
{
    public bool IsLoading { get; set; }
}
```
This would allow you to have a reducer for all actions that implement IStartFetchAction
```public class StartFetchReducer : IReducer<VisualState, IStartFetchAction>
{
    public VisualState Reduce(VisualState state, IStartFetchAction action)
    {
        return new VisualState
        {
            IsLoading = true
        };
    }
}
```
**Code Changes**
Ths biggest change is in GetReducersForAction. Instead of getting the reducers for TAction, you create a list of accepted lookups, starting with the concrete action class and iterating all the implemented interfaces other than IAction (If you wanted a reducer on IAction, you probably want a new middleware). I chose to break after the first match, but we could continue to find all the matches.
After getting all reducers, do as before, iterating all and calling reduce.