### PR TITLE
Extra semicolon on ConfigureServices

### DIFF
--- a/samples/03-ReduxDevToolsIntegration/README.md
+++ b/samples/03-ReduxDevToolsIntegration/README.md
@@ -11,7 +11,7 @@ public void ConfigureServices(IServiceCollection services)
 		.AddMiddleware<Blazor.Fluxor.ReduxDevTools.ReduxDevToolsMiddleware>()
 		.AddMiddleware<Blazor.Fluxor.Routing.RoutingMiddleware>()
 	);
-};
+}
 ```
 
 ## Required changes to state classes


### PR DESCRIPTION
Tiny typo, but causes an error if you copy-paste.