### PR TITLE
Refactored to use a SearchInProgressAction

### DIFF
--- a/samples/05-FlightFinder/FlightFinder/FlightFinder.Client/Components/Search.razor
+++ b/samples/05-FlightFinder/FlightFinder/FlightFinder.Client/Components/Search.razor
@@ -7,7 +7,7 @@
 		<div class="col pr-0">
 			<div class="form-control d-flex">
 				<div><i>✈</i>&nbsp;&nbsp;From:</div>
-				<input list="airports" placeholder="..." bind=criteria.FromAirport />
+				<input list="airports" placeholder="..." @bind="criteria.FromAirport" />
 			</div>
 		</div>
 		<div class="col px-2 py-1 align-self-end arrow">➝</div>
@@ -16,7 +16,7 @@
 		<div class="col pl-0">
 			<div class="form-control d-flex">
 				<div><i>✈</i>&nbsp;&nbsp;To:</div>
-				<input list="airports" placeholder="..." bind=criteria.ToAirport />
+				<input list="airports" placeholder="..." @bind="criteria.ToAirport" />
 			</div>
 		</div>
 	</div>
@@ -27,7 +27,7 @@
 		<div class="col pr-0">
 			<div class="form-control d-flex">
 				<div><i>🗓</i>&nbsp;&nbsp;Depart:</div>
-				<input type="date" bind=criteria.OutboundDate format-value="yyyy-MM-dd" />
+				<input type="date" @bind="criteria.OutboundDate" @bind:format="yyyy-MM-dd" />
 			</div>
 		</div>
 		<div class="col px-2 py-1 align-self-end arrow">➝</div>
@@ -36,7 +36,7 @@
 		<div class="col pl-0">
 			<div class="form-control d-flex">
 				<div><i>🗓</i>&nbsp;&nbsp;Arrive:</div>
-				<input type="date" bind=criteria.ReturnDate format-value="yyyy-MM-dd" />
+				<input type="date" @bind="criteria.ReturnDate" @bind:format="yyyy-MM-dd" />
 			</div>
 		</div>
 	</div>
@@ -44,7 +44,7 @@
 	<!-- Class / search -->
 	<div class="row py-1 d-flex px-3">
 		<div>
-			<select class="custom-select" bind=criteria.TicketClass>
+			<select class="custom-select" @bind="criteria.TicketClass">
 				<option value=@TicketClass.Economy>Economy</option>
 				<option value=@TicketClass.PremiumEconomy>Premium Economy</option>
 				<option value=@TicketClass.Business>Business</option>

--- a/samples/05-FlightFinder/FlightFinder/FlightFinder.Client/Components/SearchResults.razor
+++ b/samples/05-FlightFinder/FlightFinder/FlightFinder.Client/Components/SearchResults.razor
@@ -7,7 +7,7 @@
 	{
 		<div class="title">
 			<h2 class="my-3">@AppState.Value.SearchResults.Length results</h2>
-			<select class="custom-select" bind=chosenSortOrder>
+			<select class="custom-select" @bind="chosenSortOrder">
 				<option value=@SortOrder.Price>Cheapest</option>
 				<option value=@SortOrder.Duration>Quickest</option>
 			</select>

--- a/samples/05-FlightFinder/FlightFinder/FlightFinder.Client/Store/SearchEffect.cs
+++ b/samples/05-FlightFinder/FlightFinder/FlightFinder.Client/Store/SearchEffect.cs
@@ -19,6 +19,7 @@ namespace FlightFinder.Client.Store
 		{
 			try
 			{
+				dispatcher.Dispatch(new SearchInProgressAction());
 				Itinerary[] searchResults = await HttpClient.PostJsonAsync<Itinerary[]>("api/flightsearch", action.SearchCriteria);
 				dispatcher.Dispatch(new SearchCompleteAction(searchResults));
 			}

--- a/samples/05-FlightFinder/FlightFinder/FlightFinder.Client/Store/SearchInProgressAction.cs
+++ b/samples/05-FlightFinder/FlightFinder/FlightFinder.Client/Store/SearchInProgressAction.cs
@@ -1,0 +1,7 @@
+namespace FlightFinder.Client.Store
+{
+    public class SearchInProgressAction
+    {
+        
+    }
+}

--- a/samples/05-FlightFinder/FlightFinder/FlightFinder.Client/Store/SearchInProgressReducer.cs
+++ b/samples/05-FlightFinder/FlightFinder/FlightFinder.Client/Store/SearchInProgressReducer.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 
 namespace FlightFinder.Client.Store
 {
-	public class SearchReducer : Reducer<AppState, SearchAction>
+	public class SearchInProgressReducer : Reducer<AppState, SearchInProgressAction>
 	{
-		public override AppState Reduce(AppState state, SearchAction action)
+		public override AppState Reduce(AppState state, SearchInProgressAction action)
 		{
 			return new AppState(
 				searchInProgress: true,

--- a/samples/05-FlightFinder/FlightFinder/FlightFinder.Client/wwwroot/css/site.css
+++ b/samples/05-FlightFinder/FlightFinder/FlightFinder.Client/wwwroot/css/site.css
@@ -12,7 +12,7 @@ html {
 
 body {
     height: 100%;
-    display: flex;
+    
 }
 
 app {

--- a/samples/05-FlightFinder/FlightFinder/FlightFinder.Client/wwwroot/css/site.scss
+++ b/samples/05-FlightFinder/FlightFinder/FlightFinder.Client/wwwroot/css/site.scss
@@ -12,7 +12,6 @@ html {
 
 body {
     height: 100%;
-    display: flex;
 }
 
 app {


### PR DESCRIPTION
Also fixed binding syntax and layout.

Renaming the SearchReducer to SearchInProgressReducer and dispatching the action from the SearchAction helps with the reasoning of the flows and means the user doesn't need to know about the implementation that Reducers are triggered before Effects.