### PR TITLE
featuresbyname dictionary key check

### DIFF
--- a/src/Blazor.Fluxor/Store.cs
+++ b/src/Blazor.Fluxor/Store.cs
@@ -54,10 +54,14 @@ namespace Blazor.Fluxor
 		{
 			if (feature == null)
 				throw new ArgumentNullException(nameof(feature));
-
-			lock (SyncRoot)
-			{
-				FeaturesByName.Add(feature.GetName(), feature);
+			foreach (string f in FeaturesByName.Keys) {
+				Console.WriteLine(f);
+			}
+			if (!FeaturesByName.ContainsKey(feature.GetName())) {
+				lock (SyncRoot)
+				{
+					FeaturesByName.Add(feature.GetName(), feature);
+				}
 			}
 		}
 


### PR DESCRIPTION
ref issue #122 

This fix checks to see if the feature has already been cataloged before acquiring a lock for insertion.

Would a concurrentdictionary be a better fit here since it handles the lock internally?