### PR TITLE
Replace ComponentBase with IHandleEvent

### DIFF
--- a/src/Blazor.Fluxor/IFeature.cs
+++ b/src/Blazor.Fluxor/IFeature.cs
@@ -45,16 +45,29 @@ namespace Blazor.Fluxor
 		void ReceiveDispatchNotificationFromStore(object action);
 
 		/// <summary>
-		/// Registers a component to be re-rendered whenever the state changes
+		/// Registers a component to be re-rendered whenever the state changes, or notifies a non-rendering subscriber
 		/// </summary>
-		/// <param name="subscriber">The component that will have <see cref="ComponentBase.StateHasChanged"/> executed when the state changes</param>
-		void Subscribe(ComponentBase subscriber);
+		/// <param name="subscriber">
+		/// The component that will have <see cref="IHandleEvent.HandleEventAsync(EventCallbackWorkItem, object)"/>
+		/// executed when the state changes
+		/// </param>
+		/// <remarks>
+		/// <para>
+		/// <c>HandleEventAsync</c> is only passed an empty delegate, but always calls <see cref="ComponentBase.StateHasChanged"/>
+		/// in its own <c>Task</c> context.
+		/// </para>
+		/// </remarks>
+		/// </remarks>
+		void Subscribe(IHandleEvent subscriber);
 
 		/// <summary>
 		/// Stops a component from being re-rendered whenever the state changes
 		/// </summary>
-		/// <param name="subscriber">The component that has <see cref="ComponentBase.StateHasChanged"/> executed when the state changes</param>
-		void Unsubscribe(ComponentBase subscriber);
+		/// <param name="subscriber">
+		/// The component that has <see cref="IHandleEvent.HandleEventAsync(EventCallbackWorkItem, object)"/>
+		/// executed when the state changes
+		/// </param>
+		void Unsubscribe(IHandleEvent subscriber);
 	}
 
 	/// <summary>

--- a/src/Blazor.Fluxor/IState.cs
+++ b/src/Blazor.Fluxor/IState.cs
@@ -12,14 +12,14 @@ namespace Blazor.Fluxor
 		/// <summary>
 		/// Registers a component to be re-rendered whenever the state changes
 		/// </summary>
-		/// <param name="subscriber">The component that will have <see cref="ComponentBase.StateHasChanged"/> executed when the state changes</param>
-		void Subscribe(ComponentBase subscriber);
+		/// <param name="subscriber">The component that will have <see cref="IHandleEvent.HandleEventAsync(EventCallbackWorkItem, object)"/> executed when the state changes</param>
+		void Subscribe(IHandleEvent subscriber);
 
 		/// <summary>
 		/// Stops a component from being re-rendered whenever the state changes
 		/// </summary>
-		/// <param name="subscriber">The component that has <see cref="ComponentBase.StateHasChanged"/> executed when the state changes</param>
-		void Unsubscribe(ComponentBase subscriber);
+		/// <param name="subscriber">The component that has <see cref="IHandleEvent.HandleEventAsync(EventCallbackWorkItem, object)"/> executed when the state changes</param>
+		void Unsubscribe(IHandleEvent subscriber);
 	}
 
 	/// <summary>

--- a/src/Blazor.Fluxor/State.cs
+++ b/src/Blazor.Fluxor/State.cs
@@ -33,10 +33,10 @@ namespace Blazor.Fluxor
 			remove { Feature.StateChanged -= value; }
 		}
 
-		/// <see cref="IState.Subscribe(ComponentBase)"/>
-		public void Subscribe(ComponentBase subscriber) => Feature.Subscribe(subscriber);
+		/// <see cref="IState.Subscribe(IHandleEvent)"/>
+		public void Subscribe(IHandleEvent subscriber) => Feature.Subscribe(subscriber);
 
-		/// <see cref="IState.Unsubscribe(ComponentBase)"/>
-		public void Unsubscribe(ComponentBase subscriber) => Feature.Unsubscribe(subscriber);
+		/// <see cref="IState.Unsubscribe(IHandleEvent)"/>
+		public void Unsubscribe(IHandleEvent subscriber) => Feature.Unsubscribe(subscriber);
 	}
 }


### PR DESCRIPTION
A lot of reflection in the `Feature()` constructor can be avoided by stepping back from `ComponentBase` and using its contractual notification channel,`public Task IHandleEvent.HandleEventAsync(*,*)`.

Here's the ComponentBase implementation as of this commit, and it calls StateHasChanged() internally:
https://github.com/dotnet/aspnetcore/blob/57741cfd30fb35a184af54a5e56c7a2f2b81bf0e/src/Components/Components/src/ComponentBase.cs#L304

Stepping back to the interface allows components with a different inheritance chain to still subscribe to state changes and opens the door for non-components to also receive them by implementing `IHandleEvent`.